### PR TITLE
Fixed Launch Camera Bug

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,12 +24,12 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.0.1'
-    compile 'com.android.support:design:25.0.1'
-    compile 'com.android.support:recyclerview-v7:25.0.1'
-    compile 'com.android.support:cardview-v7:25.0.1'
+    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:cardview-v7:25.1.0'
     compile 'com.squareup.picasso:picasso:2.5.2'
     compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'com.android.support:support-v4:25.0.1'
+    compile 'com.android.support:support-v4:25.1.0'
     testCompile 'junit:junit:4.12'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,16 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".View.PhotoActivity"></activity>
+        <activity android:name=".View.PhotoActivity" />
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/rooksoto/c4q/nyc/memefactory/View/StartScreenFragment.java
+++ b/app/src/main/java/rooksoto/c4q/nyc/memefactory/View/StartScreenFragment.java
@@ -7,6 +7,7 @@ import android.os.Environment;
 import android.provider.MediaStore;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v4.content.FileProvider;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -71,7 +72,9 @@ public class StartScreenFragment extends Fragment {
                         .getApplicationContext()
                         .getExternalFilesDir(Environment.DIRECTORY_PICTURES);
                 output = new File(imageLocation, IMAGEFILENAME);
-                intent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(output));
+                intent.putExtra(MediaStore.EXTRA_OUTPUT, FileProvider.getUriForFile(
+                        getContext(),
+                        getContext().getApplicationContext().getPackageName() + ".provider", output));
                 startActivityForResult(intent, CAMERA_REQUEST_CODE);
             }
         };
@@ -98,7 +101,7 @@ public class StartScreenFragment extends Fragment {
             startActivity(intent);
         }
 
-        if (resultCode == RESULT_OK && requestCode == CAMERA_REQUEST_CODE){
+        if (resultCode == RESULT_OK && requestCode == CAMERA_REQUEST_CODE) {
             Toast.makeText(getContext(), "Saved to Gallery", Toast.LENGTH_LONG).show();
         }
     }

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+</paths>


### PR DESCRIPTION
Camera was crashing

fixed by adding provider in manifest and provider paths in res; apparently we needed to use FileProvider class

Might've been an API level issue